### PR TITLE
Turned this into releasable, working plugin

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,19 +1,34 @@
 ## General Plugin Configuration ##
-#Do you want to use an economy plugin? If so, install vault and set this to "true" (Without qoutes)
+# Do you want to use an economy plugin? If so, install vault and set this to "true" (Without qoutes)
 vault: false
-#If vault is set to true, then you can set the prices for the gadgets here
+
+# If vault is set to true, then you can set the prices for the gadgets here.
 Gadget_Prices:
     # 0 will be classed as "Free"
-    #The price of the gadget will be added to the item's lore automatically. If you want to change the message, you can find
+    # The price of the gadget will be added to the item's lore automatically. If you want to change the message, you can find
     # it in the messages.yml file.
     horseGadget: 0
     paintballGadget: 0
     mobcannonGadget: 0
-    disguisegadget: 0
+    disguiseGadget: 0
+
+# In which worlds will players receive the Gadget Selector gadget upon login?
+# You should put your hub worlds in this setting. Delete the original list if you want to; it's just an example.
+guiGadgetWorlds:
+- Hub
+- Spawn
+# In which slot in the player's hotbar should the Gadget Selector be placed? (5 is the middle)
+guiGadgetSlot: 5
 
 ## Disguise Gadget Settings ##
-#This is a list of mobs that the players can disguise as (Look at mob cannon settings for a list of mobs)
-Disguises_List: ["BLAZE", "SHEEP", "WOLF", "IRON_GOLEM", "ZOMBIE", "SKELETON"]
+# This is a list of mobs that the players can disguise as (Look at mob cannon settings for a list of mobs)
+Disguises_List:
+- BLAZE
+- SHEEP
+- WOLF
+- IRON_GOLEM
+- ZOMBIE
+- SKELETON
 
 ## Mob Cannon Settings ##
 # Available mob types (caps don't matter):
@@ -36,7 +51,7 @@ Disguises_List: ["BLAZE", "SHEEP", "WOLF", "IRON_GOLEM", "ZOMBIE", "SKELETON"]
 # SKELETON
 # SNOWMAN
 # SPIDER
-# SQUID (Notice: Squid doens't launch very far, just spawns and drops.)
+# SQUID (Notice: Squid doesn't launch very far, just spawns and drops.)
 # VILLAGER
 # WITCH
 # WOLF
@@ -50,8 +65,8 @@ simpleBlacklist: true
 
 # Which of the mobs above should be impossible to use?
 # If simpleBlacklist is set to false, this will still override the mobs you
-# have listed below. If you want mobs listed below to be usable, be sure that
-# they're not present in this list.
+# have listed in the next setting. If you want mobs listed farther down to
+# be usable, be sure that they're not present in this list.
 blacklist:
 - GIANT
 

--- a/messages.yml
+++ b/messages.yml
@@ -1,81 +1,97 @@
-#This is the messages file for the plugin MVPGadgets.
+# This is the messages file for the plugin MVPGadgets.
 
-#The text " (Gadget)" will automatically be appended to the names
+# The text " (Gadget)" will automatically be appended to the names.
 Gadgets:
-    #General messages for the gadgets. These will automatically be added to the item's lore
-    #How do you want to display the price (If any) to the user?
+    # General messages for the gadgets. These will automatically be added to the item's lore
+    # How do you want to display the price (If any) to the user?
     PRICE: "Price: ${COST}"
     
-    #How do you want to display whether the user has permission or not
-    #Default: "Permission: {HAS_PERMISSION}"
+    # How do you want to display whether the user has permission or not
+    # Default: "Permission: {HAS_PERMISSION}"
     PERMISSION: "Permission: {HAS_PERMISSION}"
 
-    #Positive is what to display if player has the permission
+    # Positive is what to display if player has the permission
     Positive: "&aYes"
     
-    #Negative is what to display if the player doesn't have permission
+    # Negative is what to display if the player doesn't have permission
     Negative: "&cNo"
     
-    #Gadget selector
+    # Gadget selector
     guiGadget:
-        #Name to be displayed when the user hover over with mouse/selects in hotbar
+        # Name to be displayed when the user hover over with mouse/selects in hotbar
         name: "&6Open &2Gadget &6Selector&1"
-        #Text to display in the GUI menu
+        # Text to display in the GUI menu
         inventory_name: "&cSelect a gadget:"
-    #Horse Gadget. Allows players to ride a horse, when dismounted it will explode.
+    # Horse Gadget. Allows players to ride a horse, when dismounted it will explode.
     horseGadget:
-        #Name of the gadget to display to the user
+        # Name of the gadget to display to the user
         name: "&bSpawn Horse&a"
-        #Description of the item. Will only be displayed inside the GUI
+        # Description of the item. Will only be displayed inside the GUI.
         description: [
             "Spawn a horse.",
             "Dismounting the horse will make it explode!"
         ]
-    #Allows the player to use the mobcannon
+    # Gadget that allows the player to use the mobcannon
     mobcannonGadget:
         name: "Mob Cannon! (Freaking Awesome)"
-        #Description of the item. Will only be displayed inside the GUI
+        # Description of the item. Will only be displayed inside the GUI.
         description: [
             "Get the cannons ready!",
             "This will allow you to fire exploding creatures."
         ]
-    #Paintball gadget
+    # Paintball gadget
     paintballGadget:
         name: "Paintball Gun"
-        #Description of the item. Will only be displayed inside the GUI
+        # Description of the item. Will only be displayed inside the GUI.
         description: [
             "Temporarily change blocks to coloured clay."
         ]
-    #Allows players to disguise as a mob
-    disguisegadget:
+    # Allows players to disguise as a mob
+    disguiseGadget:
         name: "Disguiser 5000"
         inventory_name: "&cSelect a disguise:"
-        #Description of the item. Will only be displayed inside the GUI
+        # Description of the item. Will only be displayed inside the GUI.
         description: [
             "Disguise yourself as a mob"
         ]
     
 Messages:
-    #Message that appears when the player selects a gadget
+    # Message that appears when the player selects a gadget
     SELECTED: "You have selected to use {GADGET}"
     
-    #Vault messages. These will only be used if vault is being used by the plugin
-    #Message that appears when the user buys the gadget
-    BOUGHT: "You have bough {GADGET} for ${COST}"
+    # Vault messages. These will only be used if vault is being used by the plugin
+    # Message that appears when the user buys the gadget
+    BOUGHT: "You have bought {GADGET} for ${COST}"
     
-    #Message that appears when the user isn't able to buy the gadget
+    # Message that appears when the user isn't able to buy the gadget
     UNABLE_BUY: "Sorry, you weren't able to buy a {GADGET} for ${COST}"
+
+    # Message that the plugin sends when users don't have permission for non-specific tasks,
+    # such as a command. Example of specific task: launching a certain mob with MobCannon.
+    # This message is not exclusively for commands, so you shouldn't use something like
+    # "You don't have permission for that command!"
+    GENERIC_NO_PERMISSION: "&c&lOops! &7You don't have permission to do this!"
+
+    # When the console tries to execute a command that only players can use
+    CONSOLE: "Sorry, this is a player-only command."
+
+    # When an administrator reloads the plugin with /mvpgadgets reload
+    RELOADED: "&aAll MVPGadgets configs have been reloaded."
+
+    # For when people try to use /gadget or actual item-gadgets in worlds which are not listed in
+    # the MVPGadgets config as hub worlds. Leave this as empty quotes to remove the message.
+    WRONG_WORLD: "&cYou are not in a hub world! An admin can change this in the MVPGadgets config."
     
     Disguises:
-        #When a player disguises themselves
+        # When a player disguises themselves
         DISGUISED: "You are now disguised as a(n) {ENTITY}"
        
-        #When player switches disguises
+        # When player switches disguises
         UPDATED: "Your disguise has been updated to a(n) {ENTITY}"
         
-        #When player removes their disguise
+        # When player removes their disguise
         REMOVED: "Your disguise has been removed"
-        #Names of the entites (Displayed in the GUI)
+        # Names of the entites (Displayed in the GUI)
         Names:
             ZOMBIE: "Zambie"
             WITHER_SKELETON: "Wither Skeleton"
@@ -108,8 +124,6 @@ Messages:
             ENDER_DRAGON: "Ender Dragon"
             MOOSHROOM: "Mooo shroom"
     MobCannon:
-        NO_PERMISSION: "&c&lOops! &7You don't have permission to do this!"
-        CONSOLE: "Sorry, this is a player only command"
         mobcannon:
             TITLE: "MobCannon commands"
             HELP: "&e/mobcannon (mbc) - This help menu."

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 main: ovh.tgrhavoc.mvpgadgets.MVPGadgets
 name: MVPGadgets
-version: 1.0
+version: 1.1.0
 softdepend: [Vault]
 authors: [pookeythekid, TGRHavoc, JoshMullins, 97WaterPolom, TheFreakLord, AdamQpzm]
 
@@ -8,9 +8,11 @@ commands:
   mvpgadgets:
     aliases: [mvp, mvpg]
     description: The main commmand for MVPGadgets!
+  gadget:
+    description: Open the Gadget GUI.
   mobcannon:
     aliases: [mbc]
-    description: Help menu for Mob Cannon.
+    description: Help menu for the Mob Cannon commands.
   mobcannonreload:
     aliases: [mobcannonrl, mcreload, mcrl, reloadmobcannon]
     description: Reload Mob Cannon.

--- a/resources/mvpgadgets_guide.html
+++ b/resources/mvpgadgets_guide.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html>
+<title>MVPGadgets Guide</title>
+<style>
+body{
+	//background-color:rgb(200,234,255);
+}
+.main{
+	margin-left: 15%;
+	margin-right: 15%;
+	margin-bottom: 5%;
+	height: 200%;
+	font-family: "arial";
+	font-size: 120%;
+}
+code {
+	background-color: rgb(238,238,238);
+	padding-left: 3px;
+	padding-right: 3px;
+}
+</style>
+<body>
+<div class="main">
+<h1 style="text-align:center">MVPGadgets Usage Guide</h1>
+<hr>
+<p>This is a reference to commands and permissions which you as an administator should be aware of.</p>
+<h2>Commands</h2>
+<ul style="list-style-type:none;">
+	<li>
+	<h3>/mvpgadgets reload</h3>
+		<ul style="font-size:90%">
+		<li>Reloads all MVPGadgets config files.</li>
+		<li>Aliases: <code>mvp, mvpg</code></li>
+		<li>Permission: <code>mvpgadgets.reload</code></li>
+		</ul>
+	</li>
+	<li>
+	<h3>/gadget</h3>
+		<ul style="font-size:90%">
+		<li>Displays Gadget Selector GUI, sets item in hand to GUI Gadget.</li>
+		<li>Permission: <code>mvpgadgets.gadget</code></li>
+		</ul>
+	</li>
+	<li>
+	<h3>/mobcannon</h3>
+		<ul style="font-size:90%">
+		<li>Help menu for the MobCannon commands.</li>
+		<li>Aliases: <code>mbc</code></li>
+		<li>Permission: <code>mvpgadgets.mobcannon.use</code></li>
+		</ul>
+	</li>
+	<li>
+	<h3>/mobcannonreload</h3>
+		<ul style="font-size:90%">
+		<li>Reloads the MVPGadgets main config file, which contains MobCannon settings.</li>
+		<li>Aliases: <code>mobcannonrl, mcreload, mcrl, reloadmobcannon</code></li>
+		<li>Permission: <code>mvpgadgets.mobcannon.reload</code></li>
+		</ul>
+	</li>
+	<li>
+	<h3>/launchmob</h3>
+		<ul style="font-size:90%">
+		<li>If player does not specify a mob, this will launch a random mob.</li>
+		<li>Aliases: <code>launch, lmob, lm</code></li>
+		<li>Permission: <code>mvpgadgets.mobcannon.launchmob.random</code></li>
+		</ul>
+	</li>
+	<li>
+	<h3>/launchmob <span><</span>mob name<span>></span></h3>
+		<ul style="font-size:90%">
+		<li>Launches a specific mob.</li>
+		<li>Aliases: <code>mobcannonrl, mcreload, mcrl, reloadmobcannon</code></li>
+		<li>Permission: <code>mvpgadgets.mobcannon.launchmob</code></li>
+		</ul>
+	</li>
+	<li>
+	<h3>/moblist</h3>
+		<ul style="font-size:90%">
+		<li>Lists all the mobs that the player has permission to launch.</li>
+		<li>Aliases: <code>listmobs, launcherlist, launchlist</code></li>
+		<li>Permission: <code>mvpgadgets.mobcannon.moblist</code></li>
+		</ul>
+	</li>
+	<li>
+	<h3>/mobnames <span><</span>mob name<span>></span></h3>
+		<ul style="font-size:90%">
+		<li>List all alternate names for a given mob name, according to the MVPGadgets config. (i.e. <i>ocelot</i> and <i>cat</i>)</li>
+		<li>Aliases: <code>altmobnames, altmobs</code></li>
+		<li>Permission: <code>mvpgadgets.mobcannon.mobnames</code></li>
+		</ul>
+	</li>
+</ul>
+<br><hr>
+<h2>Permissions</h2>
+<ul style="list-style-type:none;">
+	<li>
+	<h3>mvpgadgets.reload</h3>
+		<ul style="font-size:90%;">
+		<li>Use <code>/mvpgadgets reload</code></li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.gadget</h3>
+		<ul style="font-size:90%;">
+		<li>Use <code>/gadget</code></li>
+		</ul>
+	</li>
+	<h3>mvpgadgets.<span><</span>gadgetName<span>></span></h3>
+		<ul style="font-size:90%;">
+		<li>Grants the usage of a particular gadget based on its name in the config (or messages) file.</li>
+			<ul>
+			<li>The gadget name should be in a programming-variable format, with the first letter lowercased. Ex: <code>mvpgadgets.horseGadget</code></li>
+			<li>This is <b>case-sensitive</b>. Again, look in the config (or messages) file for exact names.</li>
+			</ul>
+		</ul>
+	</li>
+</ul>
+<p>This last bunch is all MobCannon <i>command</i> permissions (not to be confused with the MobCannon Gadget).</p>
+<ul style="list-style-type:none;">
+	<li>
+	<h3>mvpgadgets.mobcannon.use</h3>
+		<ul style="font-size:90%">
+		<li>Base help command for MobCannon.</li>
+		<li>Parents: all other <code>mvpgadgets.mobcannon.<span><</span>node<span>></span></code> permissions</li>
+		<li>Children: none</li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.mobcannon.launchmob</h3>
+		<ul style="font-size:90%">
+		<li>Base permission to be able to launch a mob.</li>
+		<li>Parents:
+			<ul>
+			<li><code>mvpgadgets.mobcannon.launchmob.random</code></li>
+			<li><code>mvpgadgets.mobcannon.launchmob.all</code></li>
+			<li><code>mvpgadgets.mobcannon.launchmob.*</code></li>
+			<li><code>mvpgadgets.mobcannon.*</code></li>
+			</ul>
+		</li>
+		<li>Children: none</li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.mobcannon.launchmob.random</h3>
+		<ul style="font-size:90%">
+		<li>Launch random mobs without specification in the <code>/launchmob [mob]</code> command.</li>
+		<li>Parents:
+			<ul>
+			<li><code>mvpgadgets.mobcannon.launchmob.*</code></li>
+			<li><code>mvpgadgets.mobcannon.*</code></li>
+			</ul>
+		</li>
+		<li>Children:
+			<ul>
+			<li><code>mvpgadgets.launchmob</code></li>
+			</ul>
+		</li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.mobcannon.launchmob.all</h3>
+		<ul style="font-size:90%">
+		<li>Permission to all mobs, but does not grant access to the random launcher.</li>
+		<li>Parents:
+			<ul>
+			<li><code>mvpgadgets.mobcannon.launchmob.*</code></li>
+			<li><code>mvpgadgets.mobcannon.*</code></li>
+			</ul>
+		</li>
+		<li>Children:
+			<ul>
+			<li><code>mvpgadgets.launchmob</code></li>
+			</ul>
+		</li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.mobcannon.launchmob.*</h3>
+		<ul style="font-size:90%">
+		<li>Permission to all mobs, as well as the random launcher.</li>
+		<li>Parents:
+			<ul>
+			<li><code>mvpgadgets.mobcannon.*</code></li>
+			</ul>
+		</li>
+		<li>Children:
+			<ul>
+			<li><code>mvpgadgets.launchmob</code></li>
+			<li><code>mvpgadgets.launchmob.random</code></li>
+			<li><code>mvpgadgets.launchmob.all</code></li>
+			</ul>
+		</li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.mobcannon.moblist</h3>
+		<ul style="font-size:90%">
+		<li>List all available mobs, meaning those that the user has permission for and, ultimately, that the config file allows.</li>
+		<li>Parents:
+			<ul>
+			<li><code>mvpgadgets.mobcannon.*</code></li>
+			</ul>
+		</li>
+		<li>Children: none</li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.mobcannon.mobnames</h3>
+		<ul style="font-size:90%">
+		<li>List all alternate names for a given mob name.</li>
+		<li>Parents:
+			<ul>
+			<li><code>mvpgadgets.mobcannon.*</code></li>
+			</ul>
+		</li>
+		<li>Children: none</li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.mobcannon.reload</h3>
+		<ul style="font-size:90%">
+		<li>Reload MobCannon.</li>
+		<li>Parents:
+			<ul>
+			<li><code>mvpgadgets.mobcannon.*</code></li>
+			</ul>
+		</li>
+		<li>Children: none</li>
+		</ul>
+	</li>
+	<li>
+	<h3>mvpgadgets.mobcannon.*</h3>
+		<ul style="font-size:90%">
+		<li>Grants all permissions related to MobCannon (aside from the usage of the MobCannon Gadget).</li>
+		<li>Parents:
+			<ul>
+			<li><code>mvpgadgets.mobcannon.*</code></li>
+			</ul>
+		</li>
+		<li>Children: none</li>
+		</ul>
+	</li>
+</ul>
+</div>
+</body>
+</html>

--- a/src/me/pookeythekid/MobCannon/MobCannon.java
+++ b/src/me/pookeythekid/MobCannon/MobCannon.java
@@ -1,4 +1,4 @@
-package me.pookeythekid.MobCannon;
+package me.pookeythekid.mobcannon;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,9 +11,7 @@ import java.util.Random;
 import java.util.Set;
 
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.Sound;
-import org.bukkit.block.BlockState;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -28,7 +26,6 @@ import org.bukkit.entity.Snowman;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.EntityBlockFormEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.PluginManager;
@@ -41,7 +38,7 @@ import com.darkblade12.particleeffect.ParticleEffect;
 /**
  * 
  * @author pookeythekid
- * @version 1.1.0
+ * @version 1.1.1
  *
  */
 public class MobCannon implements CommandExecutor, Listener {
@@ -56,14 +53,19 @@ public class MobCannon implements CommandExecutor, Listener {
 	private MVPGadgets plugin;
 	public Map<String, EntityType> usedNames = new HashMap<>();
 	private List<Snowman> snowmen = new ArrayList<>();
-	private List<BlockState> blockList = new ArrayList<>();
+	/* All things pertaining to blockList (list of launched-snowman-created snow blocks)
+	 * were removed (or at least commented out) in v1.1.1 .
+	 * They used to be necessary on top of cancelling the create event, but
+	 * for reasons unknown they are now redundant (at least in MC 1.8+).
+	 */
+	// private List<BlockState> blockList = new ArrayList<>();
 	private final Random rand = new Random();
 	public boolean enabledOnce = false;
 	private boolean registeredPerms = false;
 	private PluginManager pluginManager;
 	
 	/**
-	 * Simple constructor. Will add EntityTypes and mob aliases to the class by itself, instead of having them inputted.
+	 * Simple constructor. Will add EntityTypes and mob aliases to the instance by itself, instead of having them inputted.
 	 * Use the other constructor to customize mob aliases.
 	 * 
 	 * @param plugin The plugin that's using this cannon.
@@ -127,7 +129,8 @@ public class MobCannon implements CommandExecutor, Listener {
 	 * Exact same thing as the mobCannon(plugin, mobAliases, giants) method, except it's a constructor.
 	 * 
 	 * @param plugin The plugin that's using this cannon.
-	 * @param mobAliases Keys of actual mobs, values of acceptable mob names. An empty Set<String> String will work, since the default names (i.e. IRON_GOLEM will look like "iron_golem" and "irongolem") are generated regardless.
+	 * @param mobAliases Keys of actual mobs, values of acceptable mob names. An empty Set<String> String will work, since the default names
+	 * (i.e. IRON_GOLEM will look like "iron_golem" and "irongolem") are generated regardless.
 	 * @param giants Defines whether the plugin allows giants (hundred-foot-tall zombies) or not. Giants are not at all recommended.
 	 */
 	public MobCannon(MVPGadgets plugin, Map<EntityType, Set<String>> mobAliases, boolean giants) {
@@ -135,10 +138,12 @@ public class MobCannon implements CommandExecutor, Listener {
 	}
 
 	/**
-	 * More complex constructing method. Has input for alternate mob names and use of boss mobs and giants. Do NOT use null for any parameters.
+	 * More complex constructing method. Has input for alternate mob names and use of boss mobs and giants.
+	 * Do NOT use null for any parameters.
 	 * 
 	 * @param plugin The plugin that's using this cannon.
-	 * @param mobAliases Keys of actual mobs, values of acceptable mob names. An empty Set<String> will work, since the default names (i.e. IRON_GOLEM will look like "iron_golem" and "irongolem") are generated regardless.
+	 * @param mobAliases Keys of actual mobs, values of acceptable mob names. An empty Set<String> will work, since the default names
+	 * (i.e. IRON_GOLEM will look like "iron_golem" and "irongolem") are generated regardless.
 	 * @param giants Defines whether the plugin allows giants (hundred-foot-tall zombies) or not.
 	 */
 	public void mobCannon(MVPGadgets plugin, Map<EntityType, Set<String>> mobAliases, boolean giants) {
@@ -175,16 +180,19 @@ public class MobCannon implements CommandExecutor, Listener {
 		pluginManager = plugin.getServer().getPluginManager();
 		if (!enabledOnce) {
 			pluginManager.registerEvents(this, plugin);
-			enabledOnce = true; // Without this check, the events will register multiple times, making them fire as many times as this is called.
+			enabledOnce = true;
+			// Without this check, the events will register multiple times, making them fire as many times as this is called.
 		}
-		registerPerms(pluginManager);
+		//registerPerms(pluginManager);
 	}
 
 	/**
 	 * Register permissions to the server.
 	 * 
 	 * @param pm PluginManager to use.
+	 * @deprecated In favor of String-based permissions.
 	 */
+	@Deprecated
 	public void registerPerms(PluginManager pm) {
 		/*
 		 * Permissions layout
@@ -267,7 +275,9 @@ public class MobCannon implements CommandExecutor, Listener {
 	 * Unregister permissions from the server.
 	 * 
 	 * @param pm PluginManager to use.
+	 * @deprecated In favor of String-based permissions.
 	 */
+	@Deprecated
 	public void removePerms(PluginManager pm) {
 		if (registeredPerms) {
 			pm.removePermission("mvpgadgets.mobcannon.use");
@@ -287,12 +297,12 @@ public class MobCannon implements CommandExecutor, Listener {
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 		if (cmd.getName().equalsIgnoreCase("launchmob")) {
 			if (!sender.hasPermission("mvpgadgets.mobcannon.launchmob")) {
-				sender.sendMessage(plugin.getMessageFromConfig(BASE_PATH+".NO_PERMISSION"));
+				sender.sendMessage(plugin.getMessageFromConfig("Messages.GENERIC_NO_PERMISSION"));
 				return true;
 			}
 
 			if (!(sender instanceof Player)) {
-				sender.sendMessage(plugin.getMessageFromConfig(BASE_PATH + ".CONSOLE"));
+				sender.sendMessage(plugin.getMessageFromConfig("Messages.CONSOLE"));
 				return true;
 			}
 
@@ -316,7 +326,7 @@ public class MobCannon implements CommandExecutor, Listener {
 				if (sender.hasPermission("mobcannon.mobnames"))
 					sender.sendMessage(plugin.getMessageFromConfig(MOBCANNON + ".MOBNAMES"));
 			} else
-				sender.sendMessage(plugin.getMessageFromConfig(BASE_PATH + ".NO_PERMISSION"));
+				sender.sendMessage(plugin.getMessageFromConfig("Messages.GENERIC_NO_PERMISSION"));
 		}
 
 		if (cmd.getName().equalsIgnoreCase("mobcannonreload")) {
@@ -324,7 +334,7 @@ public class MobCannon implements CommandExecutor, Listener {
 				reloadCannon();
 				sender.sendMessage(plugin.getMessageFromConfig(MOBCANNONRELOAD + ".RELOADED"));
 			} else
-				sender.sendMessage(plugin.getMessageFromConfig(BASE_PATH + ".NO_PERMISSION"));
+				sender.sendMessage(plugin.getMessageFromConfig("Messages.GENERIC_NO_PERMISSION"));
 		}
 
 		if (cmd.getName().equalsIgnoreCase("moblist")) {
@@ -335,14 +345,14 @@ public class MobCannon implements CommandExecutor, Listener {
 						mobNames.append(name.toLowerCase() + ", ");
 				}
 				if (mobNames.length() == 0) {
-					sender.sendMessage(plugin.getMessageFromConfig(BASE_PATH + ".NO_PERMISSION"));
+					sender.sendMessage(plugin.getMessageFromConfig("Messages.GENERIC_NO_PERMISSION"));
 					return true;
 				}
 				mobNames.setLength(mobNames.length() - 2); // Remove the extra comma and space at the end
 				sender.sendMessage(
 						plugin.getMessageFromConfig(MOBLIST + ".AVAILABLE_MOBS").replace("{MOB_NAMES}", mobNames.toString()));
 			} else
-				sender.sendMessage(plugin.getMessageFromConfig(BASE_PATH + ".NO_PERMISSION"));
+				sender.sendMessage(plugin.getMessageFromConfig("Messages.GENERIC_NO_PERMISSION"));
 		}
 
 		if (cmd.getName().equalsIgnoreCase("mobnames")) {
@@ -375,7 +385,7 @@ public class MobCannon implements CommandExecutor, Listener {
 	public void reloadCannon() {
 		plugin.reloadConfig();
 		pluginManager = plugin.getServer().getPluginManager(); // Can't hurt to reinitialize it
-		removePerms(pluginManager);
+		//removePerms(pluginManager);
 		mobCannon(plugin, null);
 
 		Set<EntityType> blacklist = new HashSet<>();
@@ -537,7 +547,7 @@ public class MobCannon implements CommandExecutor, Listener {
 
 				Damageable entityD = (Damageable) entity;
 				entityD.setMaxHealth(Double.MAX_VALUE);
-				entityD.setHealth(Double.MAX_VALUE);
+				entityD.setHealth(1024D); //apparently 1.8 only allows a max of 1024.0, but setMaxHealth can far exceed that...
 
 				final Entity entity2 = entity;
 				new BukkitRunnable() {
@@ -548,10 +558,12 @@ public class MobCannon implements CommandExecutor, Listener {
 						ParticleEffect.EXPLOSION_LARGE.display(1, 1, 1, 1, 5, eloc, 100);
 						eloc.getWorld().playSound(eloc, Sound.EXPLODE, 1, 1);
 						entity2.remove();
+						/*
 						for (BlockState blockstate : blockList) {
 							blockstate.setType(Material.AIR);
 							blockstate.update(true, true);
 						}
+						 */
 					}
 				}.runTaskLater(plugin, 20);
 			} else
@@ -622,7 +634,7 @@ public class MobCannon implements CommandExecutor, Listener {
 
 			Damageable entityD = (Damageable) entity;
 			entityD.setMaxHealth(Double.MAX_VALUE);
-			entityD.setHealth(Double.MAX_VALUE);
+			entityD.setHealth(1024D);
 
 			final Entity entity2 = entity;
 			entity.setVelocity(ploc.getDirection().multiply(2));
@@ -635,10 +647,12 @@ public class MobCannon implements CommandExecutor, Listener {
 					ParticleEffect.EXPLOSION_LARGE.display(1, 1, 1, 1, 5, eloc, 100);
 					eloc.getWorld().playSound(eloc, Sound.EXPLODE, 1, 1);
 					entity2.remove();
+					/*
 					for (BlockState blockstate : blockList) {
 						blockstate.setType(Material.AIR);
 						blockstate.update(true, true);
 					}
+					 */
 				}
 
 			}.runTaskLater(plugin, 20);
@@ -689,10 +703,11 @@ public class MobCannon implements CommandExecutor, Listener {
 		Entity entity = e.getEntity();
 		if (entity.getType().equals(EntityType.SNOWMAN)) {
 			if (snowmen.contains((Snowman) entity)) {
-				blockList.add(e.getBlock().getState());
+				// blockList.add(e.getBlock().getState());
 				e.setCancelled(true);
 				e.getBlock().getState().update(true, true);
 
+				/*
 				new BukkitRunnable() {
 
 					@Override
@@ -703,18 +718,19 @@ public class MobCannon implements CommandExecutor, Listener {
 					}
 
 				}.runTaskLater(plugin, 22);
+				 */
 			}
 		}
 	}
 
+	/*
 	@EventHandler
-	public void onInteract(PlayerInteractEvent e) {
-		if (e.hasBlock()) {
-			BlockState blockstate = e.getClickedBlock().getState();
-			if (blockList.contains(blockstate))
-				blockList.remove(blockstate);
-		}
+	public void onBlockEvent(BlockEvent ev) {
+		BlockState blockstate = ev.getBlock().getState();
+		if (blockList.contains(blockstate))
+			blockList.remove(blockstate);
 	}
+	 */
 
 	public Map<String, EntityType> getUsedNames() {
 		return usedNames;

--- a/src/ovh/tgrhavoc/mvpgadgets/commands/GUIGadgetCommand.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/commands/GUIGadgetCommand.java
@@ -1,0 +1,83 @@
+package ovh.tgrhavoc.mvpgadgets.commands;
+
+import java.util.UUID;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import ovh.tgrhavoc.mvpgadgets.MVPGadgets;
+import ovh.tgrhavoc.mvpgadgets.gadgets.Gadget;
+import ovh.tgrhavoc.mvpgadgets.gadgets.guigadget.GUIGadget;
+import ovh.tgrhavoc.mvpgadgets.gadgets.guigadget.GUIGadgetListener;
+
+public class GUIGadgetCommand implements CommandExecutor {
+	
+	MVPGadgets plugin;
+	
+	public GUIGadgetCommand(MVPGadgets plugin) {
+		this.plugin = plugin;
+	}
+	
+	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+		if (cmd.getName().equalsIgnoreCase("gadget")) {
+			if (!sender.hasPermission("mvpgadgets.gadget")) {
+				sender.sendMessage(plugin.getMessageFromConfig("Messages.GENERIC_NO_PERMISSION"));
+				return true;
+			}
+			if (!(sender instanceof Player)) {
+				sender.sendMessage(plugin.getMessageFromConfig("Messages.CONSOLE"));
+				return true;
+			}
+			else {
+				Player player = (Player) sender;
+				try {
+					// don't want to open a gadget GUI if the player isn't in a hub world
+					if (plugin.getConfig().getStringList("guiGadgetWorlds").contains(player.getWorld().getName())) {
+						player.openInventory(GUIGadgetListener.getInv(player));
+						int slot;
+						if (plugin.getConfig().getInt("guiGadgetSlot") < 1)
+							slot = 0;
+						else if (plugin.getConfig().getInt("guiGadgetSlot") > 9)
+							slot = 8;
+						else slot = plugin.getConfig().getInt("guiGadgetSlot") - 1;
+						
+						GUIGadget guiGadget = new GUIGadget(plugin);
+						player.getInventory().setItem(slot, guiGadget.getItemStack());
+					} else if (!plugin.getMessageFromConfig("Messages.WRONG_WORLD").isEmpty())
+						player.sendMessage(plugin.getMessageFromConfig("Messages.WRONG_WORLD"));
+				} catch (NullPointerException npe) {
+					// player probably didn't log into the server via a hub world listed in the config, so gadgets didn't register
+					// either that, or the server reloaded with players online
+					for (Gadget gadget : plugin.getGadgets()){
+						try {
+							gadget.getClass().getConstructor(MVPGadgets.class, UUID.class).newInstance(
+									gadget.getPlugin(), player.getUniqueId());
+						} catch (Exception ex){ ex.printStackTrace(); }
+					}
+					
+					// yay, copy-pasted code because a tired programmer is a lazy one
+					// but hey, a lazy programmer is a great one am i rite
+					if (plugin.getConfig().getStringList("guiGadgetWorlds").contains(player.getWorld().getName())) {
+						player.openInventory(GUIGadgetListener.getInv(player));
+						int slot;
+						if (plugin.getConfig().getInt("guiGadgetSlot") < 1)
+							slot = 0;
+						else if (plugin.getConfig().getInt("guiGadgetSlot") > 9)
+							slot = 8;
+						else slot = plugin.getConfig().getInt("guiGadgetSlot") - 1;
+						
+						GUIGadget guiGadget = new GUIGadget(plugin);
+						player.getInventory().setItem(slot, guiGadget.getItemStack());
+					} else if (!plugin.getMessageFromConfig("Messages.WRONG_WORLD").isEmpty())
+						player.sendMessage(plugin.getMessageFromConfig("Messages.WRONG_WORLD"));
+					
+				}
+			}
+		}
+		
+		return true;
+	}
+
+}

--- a/src/ovh/tgrhavoc/mvpgadgets/commands/MVPGadgetsCommand.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/commands/MVPGadgetsCommand.java
@@ -1,0 +1,33 @@
+package ovh.tgrhavoc.mvpgadgets.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import ovh.tgrhavoc.mvpgadgets.MVPGadgets;
+
+public class MVPGadgetsCommand implements CommandExecutor {
+	
+	private MVPGadgets plugin;
+	
+	public MVPGadgetsCommand(MVPGadgets plugin) {
+		this.plugin = plugin;
+	}
+	
+	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+		if (cmd.getName().equalsIgnoreCase("mvpgadgets")) {
+			if (args.length > 0 && args[0].equalsIgnoreCase("reload")) {
+				if (!sender.hasPermission("mvpgadgets.reload")) {
+					sender.sendMessage(plugin.getMessageFromConfig("Messages.GENERIC_NO_PERMISSION"));
+					return true;
+				}
+				plugin.reloadConfig();
+				plugin.initConfigs();
+				sender.sendMessage(plugin.getMessageFromConfig("Messages.RELOADED"));
+			}
+		}
+		
+		return true;
+	}
+	
+}

--- a/src/ovh/tgrhavoc/mvpgadgets/events/GadgetHandler.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/events/GadgetHandler.java
@@ -1,6 +1,9 @@
 package ovh.tgrhavoc.mvpgadgets.events;
 
+import java.util.UUID;
+
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -36,21 +39,72 @@ public class GadgetHandler implements Listener{
 	@EventHandler
 	public void playerJoinEvent(PlayerJoinEvent e){
 		//Used to give the player the GUI when they spawn
-		e.getPlayer().getInventory().setItem(4, (new GUIGadget(ref)).getItemStack());
+		for (String str : ref.getConfig().getStringList("guiGadgetWorlds"))
+			if (e.getPlayer().getWorld().getName().equals(str)) {
+				int slot;
+				if (ref.getConfig().getInt("guiGadgetSlot") < 1)
+					slot = 0;
+				else if (ref.getConfig().getInt("guiGadgetSlot") > 9)
+					slot = 8;
+				else slot = ref.getConfig().getInt("guiGadgetSlot") - 1;
+				
+				GUIGadget guiGadget = new GUIGadget(ref);
+				e.getPlayer().getInventory().setItem(slot, guiGadget.getItemStack());
+				for (Gadget gadget : ref.getGadgets()){
+					try {
+						gadget.getClass().getConstructor(MVPGadgets.class, UUID.class).newInstance(
+								gadget.getPlugin(), e.getPlayer().getUniqueId());
+					} catch (Exception ex){ ex.printStackTrace(); }
+				}
+					
+				break;
+			}
+		
 	}
 	
 	@EventHandler
 	public void playerInteractEvent(PlayerInteractEvent e){
+		Player player = e.getPlayer();
 		if (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK){
-			if (e.getPlayer().getItemInHand().hasItemMeta()){
-				if (e.getPlayer().getItemInHand().getItemMeta().getDisplayName().contains("(Gadget)")){
-					for (Gadget g: ref.getGadgets()){
-						if (g.getItemStack().getItemMeta().getDisplayName().equals(e.getPlayer().getItemInHand().getItemMeta().getDisplayName())){
-							GadgetEvent e1 = new GadgetEvent(g, e.getPlayer());
-							Bukkit.getPluginManager().callEvent(e1);
-							e.setCancelled(true);
+			if (player.getItemInHand().hasItemMeta()){
+				if (player.getItemInHand().getItemMeta().getDisplayName().contains("(Gadget)")){
+					if (ref.getConfig().getStringList("guiGadgetWorlds").contains(player.getWorld().getName())) {
+						
+						try {
+							
+							for (Gadget g : Gadget.getOwnerGadgets(player.getUniqueId())){
+								if (g.getItemStack().getItemMeta().getDisplayName().equals(
+										player.getItemInHand().getItemMeta().getDisplayName())){
+									GadgetEvent e1 = new GadgetEvent(g, player);
+									Bukkit.getPluginManager().callEvent(e1);
+									e.setCancelled(true);
+								}
+							}
+							
+						} catch (NullPointerException npe) {
+							// player probably didn't log into the server via a hub world listed in the config, so gadgets didn't register
+							// either that, or the server reloaded with players online
+							for (Gadget gadget : ref.getGadgets()){
+								try {
+									gadget.getClass().getConstructor(MVPGadgets.class, UUID.class).newInstance(
+											gadget.getPlugin(), player.getUniqueId());
+								} catch (Exception ex){ ex.printStackTrace(); }
+							}
+							
+							// Hopefully fixed the problem, now retry the GadgetEvent firing
+							for (Gadget g : Gadget.getOwnerGadgets(player.getUniqueId())){
+								if (g.getItemStack().getItemMeta().getDisplayName().equals(
+										player.getItemInHand().getItemMeta().getDisplayName())){
+									GadgetEvent e1 = new GadgetEvent(g, player);
+									Bukkit.getPluginManager().callEvent(e1);
+									e.setCancelled(true);
+								}
+							}
+							
 						}
-					}
+						
+					} else if (!ref.getMessageFromConfig("Messages.WRONG_WORLD").isEmpty())
+							player.sendMessage(ref.getMessageFromConfig("Messages.WRONG_WORLD"));
 				}
 			}
 		}

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/DisguiseGadget.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/DisguiseGadget.java
@@ -2,6 +2,7 @@ package ovh.tgrhavoc.mvpgadgets.gadgets.disguisegadget;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -26,8 +27,16 @@ public class DisguiseGadget extends Gadget {
 	 */
 	List<EntityDisguise> disguiseList = new ArrayList<EntityDisguise>();
 	
+	public DisguiseGadget(MVPGadgets plugin, UUID owningPlayer) {
+		super(plugin, "disguiseGadget", new ItemStack(Material.SKULL_ITEM), owningPlayer);
+		
+		for (String s: plugin.getConfig().getStringList("Disguises_List")){
+			disguiseList.add(EntityDisguise.valueOf(s));
+		}
+	}
+	
 	public DisguiseGadget(MVPGadgets plugin) {
-		super(plugin, "disguisegadget", new ItemStack(Material.SKULL_ITEM));
+		super(plugin, "disguiseGadget", new ItemStack(Material.SKULL_ITEM));
 		
 		for (String s: plugin.getConfig().getStringList("Disguises_List")){
 			disguiseList.add(EntityDisguise.valueOf(s));
@@ -55,7 +64,7 @@ public class DisguiseGadget extends Gadget {
 			inv.setItem(slot, i);
 			slot ++;
 		}
-		//Allow player to unisguise
+		//Allow player to undisguise
 		ItemStack i = new ItemStack(Material.SKULL_ITEM);
 		ItemMeta m = i.getItemMeta();
 		m.setDisplayName("Remove Disguise");

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/DisguiseListener.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/DisguiseListener.java
@@ -37,15 +37,17 @@ public class DisguiseListener implements Listener{
 	}
 	
 	@EventHandler
-	public void disguiseChoseEvent(InventoryClickEvent event){
+	public void disguiseChooseEvent(InventoryClickEvent event){
 		Inventory check = disguiseGadget.getInv();
 		if (event.getInventory().getName().equals( check.getName() )){
 			event.setCancelled(true);
 			if ( event.getRawSlot() > ((9 * (((disguiseGadget.getDisguiseList().size()+1)/9)+1))) )
 				return;
 			
-			if (event.getCurrentItem() == null) //Fix for a NPE (when user clicks outside inv)
+			try {
+			if (event.getCurrentItem() == null)
 				return;
+			} catch (NullPointerException ex){ return; }
 			
 			if (event.getCurrentItem().hasItemMeta()){
 				for (EntityDisguise d: disguiseGadget.getDisguiseList())
@@ -105,12 +107,12 @@ public class DisguiseListener implements Listener{
 			p.sendMessage(plugin.getMessageFromConfig("Messages.Disguises.UPDATED").replace("{ENTITY}", type.getName(plugin)));
 		}else{
 			//Add them with a disguise
-			disguised.put(p, DisguiseFactory.getDisguiseFor(p, type, "v1_8_R3"));	
+			disguised.put(p, DisguiseFactory.getDisguiseFor(p, type, MVPGadgets.nmsVersion));
 			
 			p.sendMessage(plugin.getMessageFromConfig("Messages.Disguises.DISGUISED").replace("{ENTITY}", type.getName(plugin)));
 		}
 		
-		Bukkit.broadcastMessage(disguised.get(p).getDisguise().getClassName());
+		// Bukkit.broadcastMessage(disguised.get(p).getDisguise().getClassName());
 		
 		disguised.get(p).updateDisguise(Bukkit.getOnlinePlayers());
 		

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/MyDisguise_DEPRECATED.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/MyDisguise_DEPRECATED.java
@@ -95,7 +95,7 @@ public class MyDisguise_DEPRECATED {
 				"PacketPlayOutEntityDestroy", PackageType.MINECRAFT_SERVER,
 				new int[] { disguised.getEntityId() });
 		Object world = ReflectionUtils.invokeMethod(disguised.getWorld(),
-				"getHandle", null);
+				"getHandle", (Object[]) null);
 		Class<?> entity = Class.forName(type.getClassName());
 		
 		Object ent = ReflectionUtils.instantiateObject(entity, world);
@@ -218,6 +218,7 @@ public class MyDisguise_DEPRECATED {
 	}
 
 	// Forget this as well :3
+	@SuppressWarnings("incomplete-switch")
 	private Object handleSpecialTypes(EntityDisguise type, Object entity)
 			throws Exception {
 		switch (type) {
@@ -290,12 +291,15 @@ public class MyDisguise_DEPRECATED {
 	}
 
 	public void removeDisguise() throws Exception {
+		// Unused variables
+		/*
 		Object ppoed = ReflectionUtils.instantiateObject(
 				"PacketPlayOutEntityDestroy", PackageType.MINECRAFT_SERVER,
 				new int[] { disguised.getEntityId() });
 		Object ppones = ReflectionUtils.instantiateObject(
 				"PacketPlayOutNamedEntitySpawn", PackageType.MINECRAFT_SERVER,
 				ReflectionUtils.invokeMethod(disguised, "getHandle", null));
+		 */
 		for (Player p : Bukkit.getOnlinePlayers()) {
 			if (p.equals(disguised))
 				continue;

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/nms/DisguiseFactory.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/nms/DisguiseFactory.java
@@ -12,9 +12,9 @@ public class DisguiseFactory {
 	public static AbstractDisguise getDisguiseFor(Player player, EntityDisguises disguise, String version) {
 		try {
 			final Class<?> clazz = Class.forName("ovh.tgrhavoc.mvpgadgets.gadgets.disguisegadget.nms." + version + ".Disguise");
-			player.sendMessage("Getting to if");
+			// player.sendMessage("Getting to if");
 			if (AbstractDisguise.class.isAssignableFrom(clazz)) {
-				player.sendMessage("Hopefully sending the correct class");
+				// player.sendMessage("Hopefully sending the correct class");
 				return (AbstractDisguise)clazz.getConstructor(Player.class, EntityDisguises.class).newInstance(player, disguise);
 			}
 			
@@ -24,7 +24,8 @@ public class DisguiseFactory {
 			//github for support and to add their server.jar to dropbox so that the
 			//version can be implemented via nms
 			ex.printStackTrace();
-			player.sendMessage("Hello, sorry but, version " + version + " of minecraft doesn't seem to be supported!");
+			player.sendMessage("Hello! Sorry, but version " + version
+					+ " of CraftBukkit/Spigot doesn't seem to be supported by your server!");
 			return null;
 		}
 		

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/nms/IDisguise.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/nms/IDisguise.java
@@ -16,8 +16,11 @@ public interface IDisguise {
 	public void updateDisguise(Player...players);
 	public void updateDisguise(Collection<? extends Player> player);
 	
+	@SuppressWarnings("rawtypes")
 	public void sendPacket(Player player, Packet packet);
+	@SuppressWarnings("rawtypes")
 	public void sendPacket(Collection<? extends Player> players, Packet packet);
+	@SuppressWarnings("rawtypes")
 	public void sendPacket(Packet packet, Player...players);
 	
 	public void changeDisguise(EntityDisguises newDisguise);

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/nms/v1_8_R3/Disguise.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/disguisegadget/nms/v1_8_R3/Disguise.java
@@ -22,7 +22,7 @@ public class Disguise extends AbstractDisguise {
 	public Disguise(Player toDisguise, EntityDisguises disguise) {
 		super(toDisguise, disguise);
 		
-		Bukkit.broadcastMessage("Reflectively created disguise class for " + toDisguise.getName() + " as " + disguise.name());
+		// Bukkit.broadcastMessage("Reflectively created disguise class for " + toDisguise.getName() + " as " + disguise.name());
 	}
 
 	@Override
@@ -99,12 +99,14 @@ public class Disguise extends AbstractDisguise {
 		sendDisguise(players);
 	}
 
+	@SuppressWarnings("rawtypes")
 	@Override
 	public void sendPacket(Player player, Packet packet) {
 		CraftPlayer cP = (CraftPlayer)player;
 		cP.getHandle().playerConnection.sendPacket(packet);
 	}
 
+	@SuppressWarnings("rawtypes")
 	@Override
 	public void sendPacket(Collection<? extends Player> players, Packet packet) {
 		for(Player p: players) {
@@ -112,6 +114,7 @@ public class Disguise extends AbstractDisguise {
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	@Override
 	public void sendPacket(Packet packet, Player... players) {
 		for(Player p: players)

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/guigadget/GUIGadget.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/guigadget/GUIGadget.java
@@ -1,5 +1,7 @@
 package ovh.tgrhavoc.mvpgadgets.gadgets.guigadget;
 
+import java.util.UUID;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -12,6 +14,11 @@ public class GUIGadget extends Gadget {
 	
 	GUIGadgetListener listener;
 	
+	public GUIGadget(MVPGadgets plugin, UUID owningPlayer) {
+		super(plugin, "guiGadget", new ItemStack(Material.CHEST), owningPlayer);
+		isGUI = true;
+	}
+	
 	public GUIGadget(MVPGadgets plugin) {
 		super(plugin, "guiGadget", new ItemStack(Material.CHEST));
 		isGUI = true;
@@ -23,7 +30,7 @@ public class GUIGadget extends Gadget {
 	
 	@Override
 	public void execute(Player player) {
-		player.openInventory(listener.getInv(player));
+		player.openInventory(GUIGadgetListener.getInv(player));
 	}
 
 	@Override

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/horse/HorseGadget.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/horse/HorseGadget.java
@@ -1,6 +1,7 @@
 package ovh.tgrhavoc.mvpgadgets.gadgets.horse;
 
 import java.util.Random;
+import java.util.UUID;
 
 import org.bukkit.Material;
 import org.bukkit.entity.AnimalTamer;
@@ -9,6 +10,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.PluginManager;
 
 import ovh.tgrhavoc.mvpgadgets.MVPGadgets;
@@ -16,7 +18,11 @@ import ovh.tgrhavoc.mvpgadgets.gadgets.Gadget;
 
 public class HorseGadget extends Gadget{
 	
-	public HorseGadget(MVPGadgets plugin){
+	public HorseGadget(MVPGadgets plugin, UUID owningPlayer){
+		super(plugin, "horseGadget", new ItemStack(Material.MONSTER_EGG, 1, (byte)100), owningPlayer);
+	}
+	
+	public HorseGadget(MVPGadgets plugin) {
 		super(plugin, "horseGadget", new ItemStack(Material.MONSTER_EGG, 1, (byte)100));
 	}
 	
@@ -34,7 +40,11 @@ public class HorseGadget extends Gadget{
 		horse.setTamed(true);
 		horse.setVariant(Horse.Variant.values()[new Random().nextInt(Horse.Variant.values().length)]); //Spawn random horse type
 		horse.setOwner((AnimalTamer)player);
-		horse.getInventory().setSaddle(new ItemStack(Material.SADDLE));
+		ItemStack saddle = new ItemStack(Material.SADDLE);
+		ItemMeta itemMeta = saddle.getItemMeta();
+		itemMeta.setDisplayName(player.getName()+"'s horse's saddle");
+		saddle.setItemMeta(itemMeta);
+		horse.getInventory().setSaddle(saddle);
 		horse.setCustomName(player.getName() +"'s horse");
 		horse.setCustomNameVisible(true);
 		horse.setBreed(false);

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/horse/HorseListener.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/horse/HorseListener.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.inventory.ItemStack;
@@ -54,6 +55,17 @@ public class HorseListener implements Listener {
 				h.remove();
 			}
 		}
+	}
+	
+	// Don't want people stealing saddles now, do we.
+	@EventHandler
+	public void onInventoryClick(InventoryClickEvent ev) {
+		try {
+		if (ev.getInventory().getName().equals(ev.getWhoClicked().getName() + "'s horse")
+				&& ev.getCurrentItem().getType().equals(Material.SADDLE)
+				&& ev.getCurrentItem().getItemMeta().getDisplayName().equals(ev.getWhoClicked().getName()+"'s horse's saddle"))
+			ev.setCancelled(true);
+		} catch (NullPointerException ex){ return; } // If player clicks outside inventory. Thanks Jordan :)
 	}
 	
 	private void createExplosion(Variant variant, Location loc){

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/mobcannon/MobCannonGadget.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/mobcannon/MobCannonGadget.java
@@ -1,5 +1,7 @@
 package ovh.tgrhavoc.mvpgadgets.gadgets.mobcannon;
 
+import java.util.UUID;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -11,6 +13,10 @@ import ovh.tgrhavoc.mvpgadgets.gadgets.Gadget;
 
 public class MobCannonGadget extends Gadget {
 
+	public MobCannonGadget(MVPGadgets plugin, UUID owningPlayer) {
+		super(plugin, "mobcannonGadget", new ItemStack(Material.TRIPWIRE_HOOK), owningPlayer);
+	}
+	
 	public MobCannonGadget(MVPGadgets plugin) {
 		super(plugin, "mobcannonGadget", new ItemStack(Material.TRIPWIRE_HOOK));
 	}

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/paintballgun/BlockData.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/paintballgun/BlockData.java
@@ -1,0 +1,391 @@
+package ovh.tgrhavoc.mvpgadgets.gadgets.paintballgun;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Note;
+import org.bukkit.SkullType;
+import org.bukkit.block.Banner;
+import org.bukkit.block.Beacon;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.BrewingStand;
+import org.bukkit.block.Chest;
+import org.bukkit.block.CommandBlock;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.block.Dispenser;
+import org.bukkit.block.Dropper;
+import org.bukkit.block.Furnace;
+import org.bukkit.block.Hopper;
+import org.bukkit.block.Jukebox;
+import org.bukkit.block.NoteBlock;
+import org.bukkit.block.Sign;
+import org.bukkit.block.Skull;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.FurnaceInventory;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import ovh.tgrhavoc.mvpgadgets.MVPGadgets;
+
+/**
+ * It turns out this entire class wasn't even needed, forever RIP in peace.
+ * This has been kept as a potentially useful thing if someone else needs
+ * to edit blocks and stuff.
+ * @authors pookeythekid, Jordan Dalton
+ *
+ */
+public class BlockData {
+	
+	enum MetaType {
+		BANNER("Banner"),
+		BEACON("Beacon"),
+		BREWINGSTAND("BrewingStand"),
+		CHEST("Chest"),
+		COMMANDBLOCK("CommandBlock"),
+		CREATURESPAWNER("CreatureSpawner"),
+		DISPENSER("Dispenser"),
+		DROPPER("Dropper"),
+		FURNACE("Furnace"),
+		HOPPER("Hopper"),
+		JUKEBOX("Jukebox"),
+		NOTEBLOCK("NoteBlock"),
+		SIGN("Sign"),
+		SKULL("Skull");
+		
+		String type;
+		MetaType (String type) {
+			this.type = type;
+		}
+		public String getType() {
+			return this.type;
+		}
+	}
+	
+	private BlockState state;
+	private boolean isMetaType;
+	private MetaType metaType;
+	// boolean isInventoryHolder;
+	
+	private Banner banner;
+	private Beacon beacon;
+	private BrewingStand brewingStand;
+	private Map<Integer, ItemStack> brewingItems = new HashMap<>();
+	private Chest chest;
+	private CommandBlock commandBlock;
+	private CreatureSpawner creatureSpawner;
+	private Dispenser dispenser;
+	private Dropper dropper;
+	private Furnace furnace;
+	private Hopper hopper;
+	private Jukebox jukebox;
+	private NoteBlock noteblock;
+	private Sign sign;
+	private Skull skull;
+	
+	public BlockData(MVPGadgets plugin, Block block){
+		state = block.getState();
+		
+		switch (state.getType()) {
+		case BANNER:
+			this.metaType = MetaType.BANNER;
+			this.banner = (Banner) state;
+			this.isMetaType = true;
+			break;
+		case BEACON:
+			this.metaType = MetaType.BEACON;
+			this.beacon = (Beacon) state;
+			this.isMetaType = true;
+			break;
+		case BREWING_STAND:
+			this.metaType = MetaType.BREWINGSTAND;
+			this.brewingStand = (BrewingStand) state;
+			for (int i=0; i<4; i++) {
+				this.brewingItems.put(i, this.brewingStand.getInventory().getItem(i));
+			}
+			this.isMetaType = true;
+			break;
+		case CHEST:
+			this.metaType = MetaType.CHEST;
+			this.chest = (Chest) state;
+			this.isMetaType = true;
+			break;
+		case COMMAND:
+			this.metaType = MetaType.COMMANDBLOCK;
+			this.commandBlock = (CommandBlock) state;
+			this.isMetaType = true;
+			break;
+		case MOB_SPAWNER:
+			this.metaType = MetaType.CREATURESPAWNER;
+			this.creatureSpawner = (CreatureSpawner) state;
+			this.isMetaType = true;
+			break;
+		case DISPENSER:
+			this.metaType = MetaType.DISPENSER;
+			this.dispenser = (Dispenser) state;
+			this.isMetaType = true;
+			break;
+		case DROPPER:
+			this.metaType = MetaType.DROPPER;
+			this.dropper = (Dropper) state;
+			this.isMetaType = true;
+			break;
+		case FURNACE:
+			this.metaType = MetaType.FURNACE;
+			this.furnace = (Furnace) state;
+			this.isMetaType = true;
+			break;
+		case HOPPER:
+			this.metaType = MetaType.HOPPER;
+			this.hopper = (Hopper) state;
+			this.isMetaType = true;
+			break;
+		case JUKEBOX:
+			this.metaType = MetaType.JUKEBOX;
+			this.jukebox = (Jukebox) state;
+			this.isMetaType = true;
+			break;
+		case NOTE_BLOCK:
+			this.metaType = MetaType.NOTEBLOCK;
+			this.noteblock = (NoteBlock) state;
+			this.isMetaType = true;
+			break;
+		case SIGN_POST:
+			this.metaType = MetaType.SIGN;
+			this.sign = (Sign) state;
+			this.isMetaType = true;
+			break;
+		case WALL_SIGN:
+			this.metaType = MetaType.SIGN;
+			this.sign = (Sign) state;
+			this.isMetaType = true;
+			break;
+		case SKULL:
+			this.metaType = MetaType.SKULL;
+			this.skull = (Skull) state;
+			this.isMetaType = true;
+			break;
+		default:
+			this.metaType = null;
+			this.isMetaType = false;
+			break;
+		}
+		
+		Bukkit.broadcastMessage(String.valueOf(isMetaType));
+		if (this.isMetaType)
+			Bukkit.broadcastMessage(this.metaType.toString());
+		// End constructor
+	}
+	
+	public Material getMaterial() {
+		return this.state.getType();
+	}
+	public BlockState getData() {
+		return state;
+	}
+	public boolean isMetaType() {
+		return this.isMetaType;
+	}
+	public MetaType getMetaType() {
+		return this.metaType;
+	}
+	public Banner getBanner() {
+		return this.banner;
+	}
+	public Beacon getBeacon() {
+		return this.beacon;
+	}
+	public BrewingStand getBrewingStand() {
+		return this.brewingStand;
+	}
+	public Chest getChest() {
+		return this.chest;
+	}
+	public CommandBlock getCommandBlock() {
+		return this.commandBlock;
+	}
+	public CreatureSpawner getCreatureSpawner() {
+		return this.creatureSpawner;
+	}
+	public Dispenser getDispenser() {
+		return this.dispenser;
+	}
+	public Dropper getDropper() {
+		return this.dropper;
+	}
+	public Furnace getFurnace() {
+		return this.furnace;
+	}
+	public Hopper getHopper() {
+		return this.hopper;
+	}
+	public Jukebox getJukebox() {
+		return this.jukebox;
+	}
+	public NoteBlock getNoteblock() {
+		return this.noteblock;
+	}
+	public Sign getSign() {
+		return this.sign;
+	}
+	public Skull getSkull() {
+		return this.skull;
+	}
+	
+	public void updateSpecialState(BlockData data) {
+		if (data.isMetaType())
+			switch (data.getMetaType()) {
+			case BANNER:
+				Banner banner = data.getBanner();
+				List<Pattern> patterns = banner.getPatterns();
+				banner.update(true);
+				Banner banner2 = (Banner) banner.getBlock().getState();
+				banner2.setPatterns(patterns);
+				banner2.update(true);
+				break;
+			case BEACON:
+				Beacon beacon = data.getBeacon();
+				/*
+				BeaconState beaconState = new BeaconState(beacon);
+				PotionEffectType potEffectPrimary = beaconState.getPrimary();
+				PotionEffectType potEffectSecondary = beaconState.getSecondary();
+				*/
+				beacon.update(true);
+				Beacon beacon2 = (Beacon) beacon.getBlock().getState();
+				/*
+				BeaconState beaconState2 = new BeaconState(beacon2);
+				beaconState2.setPrimary(potEffectPrimary);
+				beaconState2.setSecondary(potEffectSecondary);
+				*/
+				beacon2.update(true);
+				break;
+			case BREWINGSTAND:
+				BrewingStand brewingStand = data.getBrewingStand();
+				//Bukkit.broadcastMessage(String.valueOf(brewingStand.getInventory().getItem(0).getAmount()));
+				int brewingTime = brewingStand.getBrewingTime();
+				brewingStand.update(true);
+				BrewingStand brewingStand2 = (BrewingStand) brewingStand.getBlock().getState();
+				ItemStack item1 = this.brewingItems.get(0);
+				ItemStack item2 = this.brewingItems.get(1);
+				ItemStack item3 = this.brewingItems.get(2);
+				ItemStack item4 = this.brewingItems.get(3);
+				brewingStand2.getInventory().setContents(new ItemStack[] {item1, item2, item3, item4});
+				brewingStand2.setBrewingTime(brewingTime);
+				brewingStand2.update(true);
+				break;
+			case CHEST:
+				Chest chest = data.getChest();
+				Inventory chestInv = chest.getBlockInventory();
+				chest.update(true);
+				Chest chest2 = (Chest) chest.getBlock().getState();
+				chest2.getBlockInventory().setContents(chestInv.getContents());
+				chest2.update(true);
+				break;
+			case COMMANDBLOCK:
+				CommandBlock commandBlock = data.getCommandBlock();
+				String command = commandBlock.getCommand();
+				String name = commandBlock.getName();
+				commandBlock.update(true);
+				CommandBlock commandBlock2 = (CommandBlock) commandBlock.getBlock().getState();
+				commandBlock2.setCommand(command);
+				commandBlock2.setName(name);
+				commandBlock2.update(true); //lol that rhymes (then again they all rhyme, but this one rolls off the tongue)
+				break;
+			case CREATURESPAWNER:
+				CreatureSpawner creatureSpawner = data.getCreatureSpawner();
+				int delay = creatureSpawner.getDelay();
+				EntityType spawnedType = creatureSpawner.getSpawnedType();
+				creatureSpawner.update(true);
+				CreatureSpawner creatureSpawner2 = (CreatureSpawner) creatureSpawner.getBlock().getState();
+				creatureSpawner2.setDelay(delay);
+				creatureSpawner2.setSpawnedType(spawnedType);
+				creatureSpawner2.update(true); //I guess the ones that rhyme best have 2 or more syllables
+				break;
+			case DISPENSER:
+				Dispenser dispenser = data.getDispenser();
+				Inventory dispenserInv = dispenser.getInventory();
+				dispenser.update(true);
+				Dispenser dispenser2 = (Dispenser) dispenser.getBlock().getState();
+				dispenser2.getInventory().setContents(dispenserInv.getContents());
+				dispenser2.update(true);
+				break;
+			case DROPPER:
+				Dropper dropper = data.getDropper();
+				Inventory dropperInv = dropper.getInventory();
+				dropper.update(true);
+				Dropper dropper2 = (Dropper) dropper.getBlock().getState();
+				dropper2.getInventory().setContents(dropperInv.getContents());
+				dropper2.update(true);
+				break;
+			case FURNACE:
+				Furnace furnace = data.getFurnace();
+				short burnTime = furnace.getBurnTime();
+				short cookTime = furnace.getCookTime();
+				FurnaceInventory furnaceInv = furnace.getInventory();
+				ItemStack fuel = furnaceInv.getFuel();
+				ItemStack smelting = furnaceInv.getSmelting();
+				ItemStack result = furnaceInv.getResult();
+				furnace.update(true);
+				Furnace furnace2 = (Furnace) furnace.getBlock().getState();
+				FurnaceInventory furnaceInv2 = furnace2.getInventory();
+				furnace2.setBurnTime(burnTime);
+				furnace2.setCookTime(cookTime);
+				furnaceInv2.setFuel(fuel);
+				furnaceInv2.setSmelting(smelting);
+				furnaceInv2.setResult(result);
+				furnace2.update(true);
+				break;
+			case HOPPER:
+				Hopper hopper = data.getHopper();
+				Inventory hopperInv = hopper.getInventory();
+				hopper.update(true);
+				Hopper hopper2 = (Hopper) hopper.getBlock().getState();
+				hopper2.getInventory().setContents(hopperInv.getContents());
+				hopper2.update(true);
+				break;
+			case JUKEBOX:
+				Jukebox jukebox = data.getJukebox();
+				Material playing = jukebox.getPlaying();
+				jukebox.update(true);
+				Jukebox jukebox2 = (Jukebox) jukebox.getBlock().getState();
+				jukebox2.setPlaying(playing);
+				break;
+			case NOTEBLOCK:
+				NoteBlock noteblock = data.getNoteblock();
+				Note note = noteblock.getNote();
+				noteblock.update(true);
+				NoteBlock noteblock2 = (NoteBlock) noteblock.getBlock().getState();
+				noteblock2.setNote(note);
+				noteblock2.update(true);
+				break;
+			case SIGN:
+				Sign sign = data.getSign();
+				sign.update(true);
+				Sign sign2 = (Sign) sign.getBlock().getState();
+				for (int i=0; i<sign.getLines().length; i++)
+					sign2.setLine(i, sign.getLine(i));
+				sign2.update(true);
+				break;
+			case SKULL:
+				Skull skull = data.getSkull();
+				SkullType skullType = skull.getSkullType();
+				BlockFace rotation = skull.getRotation();
+				String owner = skull.getOwner();
+				skull.update(true);
+				Skull skull2 = (Skull) skull.getBlock().getState();
+				skull2.setSkullType(skullType);
+				skull2.setRotation(rotation);
+				skull2.setOwner(owner);
+				skull2.update(true);
+				break;
+			default:
+				break;
+			}
+		else throw new IllegalArgumentException("BlockData must be a MetaType to update its special state.");
+	}
+}

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/paintballgun/PaintballGunGadget.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/paintballgun/PaintballGunGadget.java
@@ -1,5 +1,7 @@
 package ovh.tgrhavoc.mvpgadgets.gadgets.paintballgun;
 
+import java.util.UUID;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Snowball;
@@ -12,9 +14,12 @@ import ovh.tgrhavoc.mvpgadgets.gadgets.Gadget;
 
 public class PaintballGunGadget extends Gadget {
 
+	public PaintballGunGadget(MVPGadgets plugin, UUID owningPlayer) {
+		super(plugin, "paintballGadget", new ItemStack(Material.DIAMOND_BARDING), owningPlayer);
+	}
+	
 	public PaintballGunGadget(MVPGadgets plugin) {
 		super(plugin, "paintballGadget", new ItemStack(Material.DIAMOND_BARDING));
-		
 	}
 
 	@Override
@@ -25,7 +30,7 @@ public class PaintballGunGadget extends Gadget {
 
 	@Override
 	public void registerEvents(MVPGadgets plugin, PluginManager pm) {
-		return; //Listener is registered in MVPGadgets.java
+		pm.registerEvents(new PaintballListener(plugin), plugin);
 	}
 
 }

--- a/src/ovh/tgrhavoc/mvpgadgets/gadgets/paintballgun/PaintballHandler.java
+++ b/src/ovh/tgrhavoc/mvpgadgets/gadgets/paintballgun/PaintballHandler.java
@@ -1,0 +1,32 @@
+package ovh.tgrhavoc.mvpgadgets.gadgets.paintballgun;
+
+import java.util.Collection;
+
+import net.minecraft.server.v1_8_R3.BlockPosition;
+import net.minecraft.server.v1_8_R3.PacketPlayOutBlockChange;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_8_R3.util.CraftMagicNumbers;
+import org.bukkit.entity.Player;
+
+public class PaintballHandler {
+	
+	public static void sendChangeBlock(Player player, Block newBlock, Material material, byte data) {
+		PacketPlayOutBlockChange packet = new PacketPlayOutBlockChange(
+				((CraftWorld)newBlock.getWorld()).getHandle(), new BlockPosition(
+						newBlock.getLocation().getX(), newBlock.getLocation().getY(), newBlock.getLocation().getZ()));
+		packet.block = CraftMagicNumbers.getBlock(material).fromLegacyData(data);
+		CraftPlayer cP = (CraftPlayer)player;
+		cP.getHandle().playerConnection.sendPacket(packet);
+	}
+	
+	public static void updateBlock(Collection<? extends Player> players, Block block, Material material, byte data) {
+		for (Player player : players) {
+			sendChangeBlock(player, block, material, data);
+		}
+	}
+	
+}

--- a/src/ovh/tgrhavoc/utils/VaultUtil.java
+++ b/src/ovh/tgrhavoc/utils/VaultUtil.java
@@ -10,7 +10,7 @@ public class VaultUtil {
 	public static MVPGadgets plugin;
 	
 	/**
-	 * Set the plugin reference (Should be called in the onEnable method of MVPGadgets class
+	 * Set the plugin reference (Should be called in the onEnable method of MVPGadgets class)
 	 * @param plugin Plugin reference
 	 */
 	public static void setPlugin(MVPGadgets plugin){


### PR DESCRIPTION
Pretty much the title. Fixed things and stuff to make it a runnable plugin. I also fixed a crapton of bugs, so yeah :D

Actual changes I made:

* Recoded the entire paintball gun so that it uses packets now. This is much better at not destroying the contents of container blocks and signs.
 * Also massively expanded PaintballGunListener's BlockData class (and made it its own separate class), though it turned out to be useless once I went to packets.

* Redesigned the gadget-adding system. Players now own their individual sets of Gadgets; each players' gadgets have their events registered **once**. Re-registering gadgets was a major bug.
 * The MVPGadgets class's _availableGadgets_ contains ownerless gadgets, for the sake of seeing what they are without having redundant listeners registered.

* Added a few settings in messages.yml.

* Made a bunch of OCD edits throughout the code and config files.

* Wrote up an HTML file in the resources folder that covers all commands and permissions. Feel free to add to it if necessary.

* Did I say I fixed a crapton of bugs?

* Added commands /mvpgadgets reload and /gadget
 * /gadget will swap your gadget out for the GUI Gadget and open the GUI display.

* Added config settings guiGadgetWorlds and guiGadgetSlot (I think the latter is correct, too lazy to check right now). Basically self-explanatory.

* Made gadgets functional after a plugin reload with players online, instead of the plugin vomiting NPEs everywhere.

Also, I got very familiar with this plugin's code. I must say, beautiful job @TGRHavoc :)

@JoshMullins if it helps the alert